### PR TITLE
Update gen002140.sh

### DIFF
--- a/cat2/gen002140.sh
+++ b/cat2/gen002140.sh
@@ -61,7 +61,7 @@ for CURSHELL in `awk -F':' '{print $7}' /etc/passwd | sort | uniq`;do
 done
 
 # remove any that don't belong
-for BADSHELL in '/usr/bin/false /bin/false /dev/null /sbin/nologin /bin/sync /sbin/halt /sbin/shutdown sdshell'; do
+for BADSHELL in /usr/bin/false /bin/false /dev/null /sbin/nologin /bin/sync /sbin/halt /sbin/shutdown sdshell; do
 
   grep "$BADSHELL" /etc/shells > /dev/null
   if [ $? -eq 0 ]; then


### PR DESCRIPTION
The quote marks will cause the "for BADSHELL in '...' " statement to put the entire contents within the quotes into BADSHELL instead of each of the space delimited strings as intended, so nothing will ever match in the following grep statement. This has some bad repercussions later; for example, /dev/null perms will get changed to 755 in gen002220.sh (default is 666) which will break scp and sftp (took me a few hours to figure that out), among other things.
