### PR TITLE
V-38575, V-38572

### DIFF
--- a/config/audit.rules
+++ b/config/audit.rules
@@ -201,6 +201,8 @@
 #2.6.2.4.11 Ensure auditd Collects Files Deletion Events by User (successful and unsuccessful)
 -a always,exit -F arch=b32 -S unlink -S rmdir -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete
 -a always,exit -F arch=b64 -S unlink -S rmdir -S unlinkat -S rename -S renameat -F auid>=500 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S rmdir -S unlink -S unlinkat -S rename -S renameat -F auid=0 -k delete 
+-a always,exit -F arch=b64 -S rmdir -S unlink -S unlinkat -S rename -S renameat -F auid=0 -k delete 
 
 #2.6.2.4.12 Ensure auditd Collects System Administrator Actions
 -w /etc/sudoers -p wa -k actions

--- a/config/system-auth-local
+++ b/config/system-auth-local
@@ -16,7 +16,7 @@ account     sufficient    pam_succeed_if.so uid < 500 quiet
 account     required      pam_permit.so
 
 #password    required      pam_passwdqc.so min=disabled,disabled,16,12,8 random=42
-password    required      pam_cracklib.so retry=3 minlen=14 dcredit=-1 ucredit=-1 ocredit=-1 lcredit=-1 difok=3 maxrepeat=3
+password    required      pam_cracklib.so retry=3 minlen=14 dcredit=-1 ucredit=-1 ocredit=-1 lcredit=-1 difok=8 maxrepeat=3
 password    sufficient    pam_unix.so sha512 shadow try_first_pass use_authtok remember=24
 password    required      pam_deny.so
 


### PR DESCRIPTION
The XCCDF associated with the RedHat 6 STIG will result in V-38575 being flagged.  This change is meant to address that item.

Also, for V-38572, difok must be set to 8.