### PR TITLE
Update limits.conf to conform with DoD STIG

### DIFF
--- a/config/limits.conf
+++ b/config/limits.conf
@@ -50,7 +50,7 @@
 # Hard/Soft Core Limits
 * - core 0
 
-# Maxiumum of 3 sessions per user
-* - maxlogins 3
+# Maxiumum of 10 hard sessions per user
+* hard maxlogins 10
 
 # End of file


### PR DESCRIPTION
I'm proposing that we change this to the DoD STIG setting (* hard maxlogins 10) which is more relaxed. In software development environments I've found this setting to be to aggressive and impact legitimate work users are trying to perform on the workstations.