### PR TITLE
Update system-auth-local

### DIFF
--- a/config/system-auth-local
+++ b/config/system-auth-local
@@ -18,6 +18,7 @@ account     required      pam_permit.so
 #password    required      pam_passwdqc.so min=disabled,disabled,16,12,8 random=42
 password    required      pam_cracklib.so retry=3 minlen=14 dcredit=-1 ucredit=-1 ocredit=-1 lcredit=-1 difok=8 maxrepeat=3
 password    sufficient    pam_unix.so sha512 shadow try_first_pass use_authtok remember=5
+password    required      pam_pwhistory.so remember=5
 password    required      pam_deny.so
 
 session     required      pam_lastlog.so showfailed


### PR DESCRIPTION
The system must prohibit the reuse of passwords within five iterations. 
CCE-26741-9

Adding this line fixes a finding on the latest DISA STIG I've been seeing using this tool. 